### PR TITLE
Adding visionmedia/debug dep to fix for component/duo

### DIFF
--- a/component.json
+++ b/component.json
@@ -22,6 +22,7 @@
     "index.js"
   ],
   "dependencies": {
-    "webmodules/get-document": "0.1.1"
+    "webmodules/get-document": "0.1.1",
+    "visionmedia/debug": "*"
   }
 }


### PR DESCRIPTION
The `debug` dependency was left out, and it has broken component/duo builds using this module.
