### PR TITLE
typeof document.body.getBoundingClientRect == "object" in IE8

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function getBoundingClientRect (node) {
     node = range;
   }
 
-  if ('function' === typeof node.getBoundingClientRect) {
+  if (node.getBoundingClientRect) {
     rect = node.getBoundingClientRect();
 
     if (node.startContainer && rect.left === 0 && rect.top === 0) {


### PR DESCRIPTION
in IE8,

```
>> typeof document.body.getBoundingClientRect 
"object" 
```

(Related issue : https://github.com/zeroclipboard/zeroclipboard/issues/190)
